### PR TITLE
feat: migrate frontend API calls to environment-based configuration

### DIFF
--- a/client/library-app/.gitignore
+++ b/client/library-app/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+.env.local
+.env.production
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/client/library-app/package.json
+++ b/client/library-app/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
+    "build-with-ts": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/client/library-app/src/App.tsx
+++ b/client/library-app/src/App.tsx
@@ -1,7 +1,5 @@
-import { useState ,useEffect} from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
-import { UseSelector, useDispatch, useSelector } from 'react-redux';
+import { useEffect} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from './redux/ReduxStore';
 import HomePage from './pages/HomePage/HomePage';
 import { BrowserRouter,Route, Routes } from 'react-router-dom';

--- a/client/library-app/src/features/profile/components/ProfileLoanHistory/ProfileLoanHistory.tsx
+++ b/client/library-app/src/features/profile/components/ProfileLoanHistory/ProfileLoanHistory.tsx
@@ -6,6 +6,7 @@ import './ProfileLoanHistory.css';
 import { RootState } from "../../../../redux/ReduxStore";
 import { LoanRecord } from "../../../../models/LoanRecord";
 import { ProfileLoanRecord } from "../ProfileLoanRecord/ProfileLoanRecord";
+import { API_ENDPOINTS } from "../../../../config/api";
 
 
 export const ProfileLoanHistory:React.FC = () => {
@@ -15,7 +16,7 @@ export const ProfileLoanHistory:React.FC = () => {
     const fetchRecordsForUser = async () => {
         if(user){
             try{
-                let res = await axios.post('http://localhost:8000/loan/query',{
+                let res = await axios.post(`${API_ENDPOINTS.LOAN}/query`,{
                     property: "student",
                     value: user._id
                 });

--- a/client/library-app/src/redux/slices/AuthenticationSlice.ts
+++ b/client/library-app/src/redux/slices/AuthenticationSlice.ts
@@ -3,6 +3,7 @@ import { FetchUserPayload, LoginUserPayload, RegisterUserPayload, User } from ".
 
 import axios from "axios";
 import { BuildCircle, TrendingUpOutlined } from "@mui/icons-material";
+import { API_ENDPOINTS } from "../../config/api";
 
 interface AuthenticationSliceState{
     loggedInUser: User | undefined;
@@ -26,7 +27,7 @@ export const loginUser = createAsyncThunk(
     'auth/login',
     async (user:LoginUserPayload, thunkAPI) => {
         try{
-            const req = await axios.post('http://localhost:8000/auth/login',user);
+            const req = await axios.post(API_ENDPOINTS.AUTH.LOGIN, user);
             return req.data.user;
         } catch(e : any){
             const errorPayload = {
@@ -44,7 +45,7 @@ export const registerUser = createAsyncThunk(
     'auth/register',
     async(user: RegisterUserPayload, thunkAPI) => {
         try{
-            const req = await axios.post('http://localhost:8000/auth/register',user);
+            const req = await axios.post(API_ENDPOINTS.AUTH.REGISTER, user);
             return req.data.user;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -56,7 +57,7 @@ export const fetchUser = createAsyncThunk(
     'auth/fetch',
     async (payload: FetchUserPayload, thunkAPI) => {
         try{
-            const req = await axios.get(`http://localhost:8000/users/${payload.userId}`);
+            const req = await axios.get(`${API_ENDPOINTS.USERS}/${payload.userId}`);
             const user = req.data.user;
             
             return{
@@ -73,7 +74,7 @@ export const updateUser = createAsyncThunk(
     'auth/update',
     async (payload:User, thunkAPI) => {
         try{
-            const req = await axios.put('http://localhost:8000/users', payload);
+            const req = await axios.put(API_ENDPOINTS.USERS, payload);
             return req.data.user;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -85,7 +86,7 @@ export const getLibraryCard = createAsyncThunk(
     'auth/librarycard',
     async(userId:string, thunkAPI)=> {
         try{
-            const req = await axios.post('http://localhost:8000/card/', {user:userId});
+            const req = await axios.post(`${API_ENDPOINTS.CARD}/`, {user:userId});
             return req.data.libraryCard;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -114,7 +115,7 @@ export const AuthenticationSlice = createSlice({
     },
     extraReducers: (builder) => {
         //pending logic 
-        builder.addCase(loginUser.pending, (state, action) => {
+        builder.addCase(loginUser.pending, (state ) => {
             state = {
                 ...state,
                 error: false,

--- a/client/library-app/src/redux/slices/BookSlice.ts
+++ b/client/library-app/src/redux/slices/BookSlice.ts
@@ -7,6 +7,7 @@ import { PageInfo } from "../../models/Page";
 import { ListItem } from "@mui/material";
 import { act } from "react";
 import { LocalDining } from "@mui/icons-material";
+import { API_ENDPOINTS } from "../../config/api";
 
 interface BookSliceState {
     loading: boolean;
@@ -30,7 +31,7 @@ export const fetchAllBooks = createAsyncThunk(
     'book/all',
     async (payload, thunkAPI) => {
         try{
-            let req = await axios.get('http://localhost:8000/book/');
+            let req = await axios.get(API_ENDPOINTS.BOOK.BASE);
             return req.data.books;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -43,7 +44,7 @@ export const queryBooks = createAsyncThunk(
     'book/query',
     async (payload:string, thunkAPI) => {
         try{
-            let req = await axios.get(`http://localhost:8000/book/query/${payload}`);
+            let req = await axios.get(`${API_ENDPOINTS.BOOK.QUERY}/${payload}`);
             return req.data.page;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -58,7 +59,7 @@ export const checkoutBook = createAsyncThunk(
             const returnDate = new Date();
             returnDate.setDate(returnDate.getDate() + 14);
             
-            const getStudent = await axios.get(`http://localhost:8000/card/${payload.libraryCard}`);
+            const getStudent = await axios.get(`${API_ENDPOINTS.CARD}/${payload.libraryCard}`);
 
             let studentId = getStudent.data.libraryCard.user._id;
 
@@ -71,7 +72,7 @@ export const checkoutBook = createAsyncThunk(
                 item: payload.book._id
             }
 
-            const loadReq = await axios.post('http://localhost:8000/loan', record);
+            const loadReq = await axios.post(API_ENDPOINTS.LOAN, record);
             const loan = loadReq.data.record;
 
             return loan;
@@ -100,7 +101,7 @@ export const checkinBook = createAsyncThunk(
                 _id: record._id
             }
 
-            let loan = await axios.put('http://localhost:8000/loan/', updatedRecord);
+            let loan = await axios.put(`${API_ENDPOINTS.LOAN}/`, updatedRecord);
             return loan.data.record;
         } catch(e){
             return thunkAPI.rejectWithValue(e);
@@ -113,7 +114,7 @@ export const loadBookByBarcode = createAsyncThunk(
     'book/id',
     async (payload:string, thunkAPI) => {
         try{
-            let res = await axios.get(`http://localhost:8000/book/query?barcode=${payload}`);
+            let res = await axios.get(`${API_ENDPOINTS.BOOK.QUERY}?barcode=${payload}`);
             let book = res.data.page.items[0];
 
             if(!book || book.barcode !== payload){

--- a/client/library-app/vercel.json
+++ b/client/library-app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Replace hardcoded localhost URLs with centralized API endpoints
  - Update AuthenticationSlice.ts to use API_ENDPOINTS for all auth operations
  - Update BookSlice.ts to use API_ENDPOINTS for all book operations
  - Update ProfileLoanHistory.tsx to use API_ENDPOINTS for loan queries
  - Remove all hardcoded http://localhost:8000 references